### PR TITLE
Expand on Second Visit, bench: 1008163

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -88,7 +88,7 @@ pub fn to_cp(score: f32) -> i32 {
     } else if score == 0.0 {
         -MATE_SCORE
     } else {
-        (-400.0 * (1.0 / score - 1.0).ln()) as i32
+        (-(EVAL_SCALE as f32) * (1.0 / score - 1.0).ln()) as i32
     }
 }
 
@@ -240,7 +240,7 @@ impl Engine {
             let node = &self.tree[node_idx];
 
             // expansion
-            if !node.result.is_terminal() {
+            if !node.result.is_terminal() && node.visits != 0 {
                 self.expand(node_idx);
             }
 


### PR DESCRIPTION
Elo   | 56.04 +- 17.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=1MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 10.00]
Games | N: 394 W: 88 L: 25 D: 281
Penta | [1, 18, 101, 71, 6]
https://vast342.pythonanywhere.com/test/351/